### PR TITLE
ci: add ability to dry-run release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: goreleaser
 
 on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Dry run without publishing
+        type: boolean
+        default: true
   push:
     tags:
       - '*'
@@ -28,6 +34,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist ${{ inputs.dry-run && '--skip=publish' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add dry-run capabiilities to release.yml to be able to test https://github.com/elastic/docker-credfile-gen/pull/31